### PR TITLE
Add visual cue for checkpoint activation

### DIFF
--- a/Assets/Scenes/Level 1 - The crater hideout.unity
+++ b/Assets/Scenes/Level 1 - The crater hideout.unity
@@ -727,7 +727,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 26621570e756e4b1c9974e6c531e1a49, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 1
+  speed: 3
 --- !u!1 &548756319
 GameObject:
   m_ObjectHideFlags: 0
@@ -1180,7 +1180,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -246,9 +246,17 @@ public class PlayerController : MonoBehaviour
             collectible.OnCollect();
         }
 
-        if (collision.gameObject.CompareTag("Checkpoint"))
+        SetCheckpoint(collision.gameObject);
+    }
+
+    void SetCheckpoint(GameObject checkpoint)
+    {
+        if (checkpoint.CompareTag("Checkpoint") && !levelManager.checkpointReached)
         {
             levelManager.checkpointReached = true;
+
+            SpriteRenderer checkpointRenderer = checkpoint.GetComponent<SpriteRenderer>();
+            checkpointRenderer.material.color = Color.green;
         }
     }
 


### PR DESCRIPTION
Add SetCheckpoint method to PlayerController. This method does what the script has been doing before, but now it also sets the color of the checkpoint to indicate that the checkpoint has been activated. We can use this method as a basis for future checkpoint animation.

https://github.com/zamcham/scalatic-escape/assets/92247933/7bcaf318-6a44-451f-a31e-8b6136200e04


