### PR TITLE
Implement edge detection to RollingEnemy

### DIFF
--- a/Assets/Prefabs/Characters/RollingEnemy.prefab
+++ b/Assets/Prefabs/Characters/RollingEnemy.prefab
@@ -118,7 +118,7 @@ Transform:
   - {fileID: 5028535963113684016}
   - {fileID: 4457687619247073837}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &2143381311991893291
 Rigidbody2D:
@@ -162,7 +162,9 @@ MonoBehaviour:
   sprite: {fileID: 5028535963113684016}
   moveSpeed: 4
   rollDegreePerUnit: 90
-  rayMaxDistance: 1
+  collider: {fileID: 4012416081040052991}
+  horizontalRayDistance: 1
+  verticalRayDistance: 0.5
   changeDirectionDuration: 0.5
   rayMask:
     serializedVersion: 2

--- a/Assets/Scripts/Enemies/RollingEnemy.cs
+++ b/Assets/Scripts/Enemies/RollingEnemy.cs
@@ -7,12 +7,16 @@ public class RollingEnemy : EnemyBase
     [SerializeField] float moveSpeed = 2f, rollDegreePerUnit = 90;
 
     // Corner Detection
-    [SerializeField] float rayMaxDistance = 0.5f, changeDirectionDuration = 0.5f;
+    [SerializeField] new Collider2D collider;
+
+    [SerializeField] float horizontalRayDistance = 0.5f, verticalRayDistance = 0.5f, changeDirectionDuration = 0.5f;
     [SerializeField] LayerMask rayMask;
 
     float currentSpeed, currentDirection;
 
     bool changingDirection = false;
+
+    Vector3 right, left, rightBottom, leftBottom;
 
     private void Start()
     {
@@ -22,11 +26,52 @@ public class RollingEnemy : EnemyBase
 
     private void FixedUpdate()
     {
-        if (!changingDirection && 
-            (Physics2D.Raycast(transform.position, transform.right, rayMaxDistance, rayMask) ||
-            Physics2D.Raycast(transform.position, -transform.right, rayMaxDistance, rayMask)))
+        if (!changingDirection)
         {
-            StartCoroutine(ChangeDirection(-currentDirection, changeDirectionDuration, 2f));
+            // This operation is heavy so only calculate it here
+
+            // For right - left raycasts
+            right = collider.bounds.center + (collider.bounds.extents.x * Vector3.right);
+            left = collider.bounds.center - (collider.bounds.extents.x * Vector3.right);
+
+            // For bottom raycasts
+            rightBottom = collider.bounds.center + new Vector3(collider.bounds.extents.x, -collider.bounds.extents.y, 0f);
+            leftBottom = collider.bounds.center - collider.bounds.extents;
+
+            bool horizontalRaycasts = Physics2D.Raycast(right, transform.right, horizontalRayDistance, rayMask) // If there is an obstacle to our right
+            || Physics2D.Raycast(left, -transform.right, horizontalRayDistance, rayMask); // Same but left
+
+            if (horizontalRaycasts)
+            {
+                StartCoroutine(ChangeDirection(-currentDirection, changeDirectionDuration, 1f));
+            }
+            else
+            {
+                // So, there is a thing. These raycasts are so accurate that, even if there is a minimal space between two ground objects, 
+                // the enemy will change it direction. Of course this is an undesired behavior. If the space is minimal, the enemy can roll easily.
+                // So, we will consider the half of its size here. Sorry for the spaghetti code lol.
+
+                bool bottomRightRaycast = !Physics2D.Raycast(rightBottom, -transform.up, verticalRayDistance, rayMask);
+                bool bottomLeftRaycast =  !Physics2D.Raycast(leftBottom, -transform.up, verticalRayDistance, rayMask);
+
+                bool sizeRaycast = false;
+
+                Vector3 extentsHorizontal = new Vector3(collider.bounds.extents.x, 0f, 0f);
+
+                if (bottomRightRaycast)
+                {
+                    sizeRaycast = !Physics2D.Raycast(rightBottom + extentsHorizontal, -transform.up, verticalRayDistance, rayMask);
+                }
+                else if (bottomLeftRaycast)
+                {
+                    sizeRaycast = !Physics2D.Raycast(leftBottom - extentsHorizontal, -transform.up, verticalRayDistance, rayMask);
+                }
+
+                if (sizeRaycast)
+                {
+                    StartCoroutine(ChangeDirection(-currentDirection, changeDirectionDuration, 1f));
+                }
+            }           
         }
 
         Move();
@@ -67,7 +112,10 @@ public class RollingEnemy : EnemyBase
 
     private void OnDrawGizmos()
     {
-        Gizmos.DrawLine(transform.position, transform.position + (transform.right * rayMaxDistance));
-        Gizmos.DrawLine(transform.position, transform.position + (-transform.right * rayMaxDistance));
+        Gizmos.DrawLine(right, right + (transform.right * horizontalRayDistance));
+        Gizmos.DrawLine(left, left - (transform.right * horizontalRayDistance));
+
+        Gizmos.DrawLine(rightBottom, rightBottom - (transform.up * verticalRayDistance));
+        Gizmos.DrawLine(leftBottom, leftBottom - (transform.up * verticalRayDistance));
     }
 }

--- a/UserSettings/Layouts/default-2022.dwlt
+++ b/UserSettings/Layouts/default-2022.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1920
     height: 997
   m_ShowMode: 4
-  m_Title: Inspector
+  m_Title: Game
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -119,7 +119,7 @@ MonoBehaviour:
   m_MinSize: {x: 400, y: 100}
   m_MaxSize: {x: 32384, y: 16192}
   vertical: 0
-  controlID: 61
+  controlID: 123
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -139,12 +139,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1259
+    width: 1231
     height: 947
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 1
-  controlID: 62
+  controlID: 76
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -165,12 +165,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1259
+    width: 1231
     height: 617
   m_MinSize: {x: 300, y: 50}
   m_MaxSize: {x: 24288, y: 8096}
   vertical: 0
-  controlID: 63
+  controlID: 52
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -188,13 +188,13 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 198
+    width: 165
     height: 617
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 4000, y: 4000}
-  m_ActualView: {fileID: 15}
+  m_ActualView: {fileID: 16}
   m_Panes:
-  - {fileID: 15}
+  - {fileID: 16}
   m_Selected: 0
   m_LastSelected: 0
 --- !u!114 &9
@@ -212,15 +212,15 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 198
+    x: 165
     y: 0
-    width: 617
+    width: 306
     height: 617
-  m_MinSize: {x: 202, y: 221}
-  m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 16}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 17}
   m_Panes:
-  - {fileID: 16}
+  - {fileID: 17}
   m_Selected: 0
   m_LastSelected: 0
 --- !u!114 &10
@@ -238,15 +238,15 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 815
+    x: 471
     y: 0
-    width: 444
+    width: 760
     height: 617
-  m_MinSize: {x: 202, y: 221}
-  m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 14}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 15}
   m_Panes:
-  - {fileID: 14}
+  - {fileID: 15}
   m_Selected: 0
   m_LastSelected: 0
 --- !u!114 &11
@@ -266,14 +266,14 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 617
-    width: 1259
+    width: 1231
     height: 330
   m_MinSize: {x: 231, y: 271}
   m_MaxSize: {x: 10001, y: 10021}
-  m_ActualView: {fileID: 17}
+  m_ActualView: {fileID: 18}
   m_Panes:
-  - {fileID: 17}
   - {fileID: 18}
+  - {fileID: 19}
   m_Selected: 0
   m_LastSelected: 1
 --- !u!114 &12
@@ -286,24 +286,59 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: InspectorWindow
+  m_Name: ProjectSettingsWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1259
+    x: 1231
     y: 0
-    width: 661
+    width: 689
     height: 947
-  m_MinSize: {x: 275, y: 50}
+  m_MinSize: {x: 310, y: 200}
   m_MaxSize: {x: 4000, y: 4000}
-  m_ActualView: {fileID: 19}
+  m_ActualView: {fileID: 14}
   m_Panes:
-  - {fileID: 19}
+  - {fileID: 20}
+  - {fileID: 14}
   - {fileID: 13}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &13
+MonoBehaviour:
+  m_ObjectHideFlags: 52
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c66a740a74845a08dc18bab7f2ffa03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MinSize: {x: 560, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_TitleContent:
+    m_Text: Recorder
+    m_Image: {fileID: 0}
+    m_Tooltip: 
+  m_Pos:
+    serializedVersion: 2
+    x: 1035
+    y: 73
+    width: 884
+    height: 926
+  m_SerializedDataModeController:
+    m_DataMode: 0
+    m_PreferredDataMode: 0
+    m_SupportedDataModes: 
+    isAutomatic: 1
+  m_ViewDataDictionary: {fileID: 0}
+  m_OverlayCanvas:
+    m_LastAppliedPresetName: Default
+    m_SaveData: []
+    m_OverlaysVisible: 1
+--- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -323,9 +358,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1260
+    x: 1231
     y: 73
-    width: 659
+    width: 688
     height: 926
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -364,7 +399,7 @@ MonoBehaviour:
       m_IsRenamingFilename: 0
       m_ClientGUIView: {fileID: 0}
     m_SearchString: 
---- !u!114 &14
+--- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -384,9 +419,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 815
+    x: 471
     y: 73
-    width: 442
+    width: 758
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -404,7 +439,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 442, y: 276}
+  m_TargetSize: {x: 1280, y: 720}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -413,16 +448,16 @@ MonoBehaviour:
   m_VSyncEnabled: 0
   m_Gizmos: 0
   m_Stats: 0
-  m_SelectedSizes: 02000000000000000000000000000000000000000000000000000000000000000000000000000000
+  m_SelectedSizes: 08000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
     m_HRangeLocked: 0
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -221
-    m_HBaseRangeMax: 221
-    m_VBaseRangeMin: -138
-    m_VBaseRangeMax: 138
+    m_HBaseRangeMin: -640
+    m_HBaseRangeMax: 640
+    m_VBaseRangeMin: -360
+    m_VBaseRangeMax: 360
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -440,29 +475,29 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 442
+      width: 758
       height: 575
-    m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 221, y: 287.5}
+    m_Scale: {x: 0.5921875, y: 0.5921875}
+    m_Translation: {x: 379, y: 287.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -221
-      y: -287.5
-      width: 442
-      height: 575
+      x: -640
+      y: -485.4881
+      width: 1280
+      height: 970.9762
     m_MinimalGUI: 1
-  m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 442, y: 596}
+  m_defaultScale: 0.5921875
+  m_LastWindowPixelSize: {x: 758, y: 596}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
   m_XRRenderMode: 0
   m_RenderTexture: {fileID: 0}
---- !u!114 &15
+--- !u!114 &16
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -484,7 +519,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 73
-    width: 197
+    width: 164
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -499,9 +534,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 
+      m_SelectedIDs: f2660000
       m_LastClickedID: 0
-      m_ExpandedIDs: 5491ffff5891ffffd891ffffeaa6ffffeea6ffffb6a7ffffb0a8ffffaaa9ffff98adffff02aeffffeab0ffffeeb0ffffaeb1ffff2eb3ffffb4deffff96e6ffff2ee7ffff68eaffff48ecffff80faffff427d0000607f00008a840000148e0000
+      m_ExpandedIDs: 0efbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -525,7 +560,7 @@ MonoBehaviour:
       m_IsLocked: 0
     m_CurrentSortingName: TransformSorting
   m_WindowGUID: 4c969a2b90040154d917609493e03593
---- !u!114 &16
+--- !u!114 &17
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -545,9 +580,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 198
+    x: 165
     y: 73
-    width: 615
+    width: 304
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -894,9 +929,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 22.79332, y: -2.5442188, z: -0.11435057}
+    m_Target: {x: 20.25721, y: -0.3847085, z: -0.060034387}
     speed: 2
-    m_Value: {x: 22.79332, y: -2.5442188, z: -0.11435057}
+    m_Value: {x: 20.25721, y: -0.3847085, z: -0.060034387}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -946,9 +981,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 2.0529668
+    m_Target: 1.9162426
     speed: 2
-    m_Value: 2.0529668
+    m_Value: 1.9162426
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -973,7 +1008,7 @@ MonoBehaviour:
   m_SceneVisActive: 1
   m_LastLockedObject: {fileID: 0}
   m_ViewIsLockedToObject: 0
---- !u!114 &17
+--- !u!114 &18
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -995,7 +1030,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 690
-    width: 1258
+    width: 1230
     height: 309
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1018,7 +1053,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Prefabs/Characters/Mushroom
+    - Assets
     m_Globs: []
     m_OriginalText: 
     m_ImportLogFlags: 0
@@ -1026,16 +1061,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/Prefabs/Characters/Mushroom
+  - Assets
   m_LastFoldersGridSize: -1
   m_LastProjectPath: D:\Unity\Projects\scalatic-escape
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 826a0000
-    m_LastClickedID: 27266
-    m_ExpandedIDs: 00000000926600009466000096660000986600009a6600009c6600009e660000a0660000a2660000a4660000a6660000f8660000
+    m_SelectedIDs: da660000
+    m_LastClickedID: 26330
+    m_ExpandedIDs: 00000000c6660000c8660000ca660000cc660000ce660000d0660000d2660000d4660000d6660000d8660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1063,7 +1098,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000926600009466000096660000986600009a6600009c6600009e660000a0660000a2660000a4660000a6660000
+    m_ExpandedIDs: 00000000c6660000c8660000ca660000cc660000ce660000d0660000d2660000d4660000d6660000d8660000da660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1119,7 +1154,7 @@ MonoBehaviour:
     m_GridSize: 64
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 250
---- !u!114 &18
+--- !u!114 &19
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1141,7 +1176,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 690
-    width: 1258
+    width: 1221
     height: 309
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1153,7 +1188,7 @@ MonoBehaviour:
     m_LastAppliedPresetName: Default
     m_SaveData: []
     m_OverlaysVisible: 1
---- !u!114 &19
+--- !u!114 &20
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1173,9 +1208,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1259
+    x: 1035
     y: 73
-    width: 660
+    width: 884
     height: 926
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1193,7 +1228,7 @@ MonoBehaviour:
     m_CachedPref: 160
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
-  m_LastInspectedObjectInstanceID: -1
+  m_LastInspectedObjectInstanceID: 26354
   m_LastVerticalScrollValue: 0
   m_GlobalObjectId: 
   m_InspectorMode: 0


### PR DESCRIPTION
Rolling Enemies now have the ability to detect edges, and thus change direction and sucesfully evade the danger of falling through an infinite hole 😆 

The full process is now like this:

- It checks its right and left for walls and corners, like it did before.
- If there is nothing, it then it checks for its bottom right and bottom left corners for edges.
- If it can't hit something, then that means there is a hole ahead. But we also need the size of the hole. So, it then casts an additional raycast to determine the size of the hole, and if it is smaller than half of its size, it continues rolling in that direction because that means it can sucessfully pass that hole without falling. However, if the hole is larger than that, it changes its direction.

> Here is a quick video to showcase it:

https://github.com/zamcham/scalatic-escape/assets/92247933/7c5bbf51-249e-4b2a-a335-386910e26444



