### PR TITLE
Add Speed Boost feature to Nomad & Pixie 

### DIFF
--- a/Assets/Input System/scalatic escape.inputactions
+++ b/Assets/Input System/scalatic escape.inputactions
@@ -67,6 +67,42 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "NomadSpeedBoost",
+                    "type": "Button",
+                    "id": "b5f53b84-8f62-4a4b-9d6b-c9b46fa626f3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PixieSpeedBoostCombo1",
+                    "type": "Button",
+                    "id": "1608796c-ecfa-4b71-a1e0-f4c118f16bfc",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PixieSpeedBoostCombo2",
+                    "type": "Button",
+                    "id": "e80bddea-3e8b-4d98-bde6-6c2dc0213713",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PixieSpeedBoostCombo3",
+                    "type": "Button",
+                    "id": "e50cb04b-330b-42aa-a134-f933c5475a70",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -331,6 +367,50 @@
                     "processors": "",
                     "groups": "",
                     "action": "Nomad",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7cacc560-3703-4b65-82bc-7a58b6480bfa",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "NomadSpeedBoost",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "239ba613-f5fe-4e3f-8693-624844fba792",
+                    "path": "<Keyboard>/z",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PixieSpeedBoostCombo1",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2f9a2b33-262c-4417-b87d-3eae86a6035e",
+                    "path": "<Keyboard>/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PixieSpeedBoostCombo2",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3770677b-a8ae-4fda-993f-b01b0b5c47c9",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PixieSpeedBoostCombo3",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scenes/Level 1 - The crater hideout.unity
+++ b/Assets/Scenes/Level 1 - The crater hideout.unity
@@ -3439,6 +3439,30 @@ PrefabInstance:
       propertyPath: moveSpeed
       value: 12
       objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: speedBoostCooldown
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: speedBoostDuration
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: nomadJumpBoostMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: pixieJumpBoostMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: nomadSpeedBoostMultiplier
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734992756464308382, guid: cecdd651ddcb04ed58374b8a873eb4c0, type: 3}
+      propertyPath: pixieSpeedBoostMultiplier
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
+++ b/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
@@ -24,7 +24,7 @@ MonoBehaviour:
   m_MinSize: {x: 400, y: 100}
   m_MaxSize: {x: 32384, y: 16192}
   vertical: 0
-  controlID: 6483
+  controlID: 50
 --- !u!114 &2
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -45,9 +45,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 580
+    x: 536
     y: 73
-    width: 465
+    width: 649
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 465, y: 262}
+  m_TargetSize: {x: 649, y: 365}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -80,10 +80,10 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -232.5
-    m_HBaseRangeMax: 232.5
-    m_VBaseRangeMin: -131
-    m_VBaseRangeMax: 131
+    m_HBaseRangeMin: -324.5
+    m_HBaseRangeMax: 324.5
+    m_VBaseRangeMin: -182.5
+    m_VBaseRangeMax: 182.5
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -101,23 +101,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 465
+      width: 649
       height: 575
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 232.5, y: 287.5}
+    m_Translation: {x: 324.5, y: 287.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -232.5
+      x: -324.5
       y: -287.5
-      width: 465
+      width: 649
       height: 575
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 465, y: 596}
+  m_LastWindowPixelSize: {x: 649, y: 596}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
@@ -142,12 +142,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1047
+    width: 1187
     height: 947
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 1
-  controlID: 6484
+  controlID: 51
 --- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -168,12 +168,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1047
+    width: 1187
     height: 617
   m_MinSize: {x: 300, y: 50}
   m_MaxSize: {x: 24288, y: 8096}
   vertical: 0
-  controlID: 6485
+  controlID: 52
 --- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -191,10 +191,10 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 206
+    width: 232
     height: 617
-  m_MinSize: {x: 201, y: 221}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 6}
   m_Panes:
   - {fileID: 6}
@@ -222,7 +222,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 73
-    width: 205
+    width: 231
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -237,9 +237,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 5e9a0000
+      m_SelectedIDs: b6670000
       m_LastClickedID: 0
-      m_ExpandedIDs: b8cafeff58d8feffb0d9feff847cffffb883ffffc683fffff483ffff5685ffffe693ffff04b7ffff28c7ffff36c7ffff38c7ffffd2dcffffe0dcffff0addffff28ebffff2cebffff0efbffff4a7a0000dc7a00009282000024830000308d0000c28d0000b294000044950000ae95000040960000c89700005a980000
+      m_ExpandedIDs: d8e7ffff72edffff0cf4ffff0efbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -278,9 +278,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 206
+    x: 232
     y: 0
-    width: 374
+    width: 304
     height: 617
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -309,9 +309,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 206
+    x: 232
     y: 73
-    width: 372
+    width: 302
     height: 596
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -658,9 +658,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 16.263575, y: -2.2678978, z: -0.49674848}
+    m_Target: {x: 23.339903, y: -0.8969288, z: -1.0895945}
     speed: 2
-    m_Value: {x: 16.263575, y: -2.2678978, z: -0.49674848}
+    m_Value: {x: 23.339903, y: -0.8969288, z: -1.0895945}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -710,9 +710,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 1.4276462
+    m_Target: 1.0950165
     speed: 2
-    m_Value: 1.4276462
+    m_Value: 1.0950165
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -752,9 +752,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 580
+    x: 536
     y: 0
-    width: 467
+    width: 651
     height: 617
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -780,7 +780,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 617
-    width: 1047
+    width: 1187
     height: 330
   m_MinSize: {x: 101, y: 121}
   m_MaxSize: {x: 4001, y: 4021}
@@ -812,7 +812,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 690
-    width: 1046
+    width: 1186
     height: 309
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -835,7 +835,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Scenes
+    - Assets/Input System
     m_Globs: []
     m_OriginalText: 
     m_ImportLogFlags: 0
@@ -843,16 +843,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/Scenes
+  - Assets/Input System
   m_LastFoldersGridSize: -1
   m_LastProjectPath: D:\Unity\Projects\scalatic-escape
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: f4660000
-    m_LastClickedID: 26356
-    m_ExpandedIDs: 00000000ca660000cc660000ce660000d0660000d2660000d4660000d6660000d8660000da660000dc660000ec660000f2660000
+    scrollPos: {x: 0, y: 31}
+    m_SelectedIDs: fc660000
+    m_LastClickedID: 26364
+    m_ExpandedIDs: 00000000be660000c0660000c2660000c4660000c6660000c8660000ca660000cc660000ce660000d0660000d2660000d4660000f6660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -880,7 +880,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000ca660000cc660000ce660000d0660000d2660000d4660000d6660000d8660000da660000dc660000f2660000
+    m_ExpandedIDs: 00000000be660000c0660000c2660000c4660000c6660000c8660000ca660000cc660000ce660000d0660000d2660000d4660000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -905,9 +905,9 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 5e9a0000
-    m_LastClickedInstanceID: 39518
-    m_HadKeyboardFocusLastEvent: 0
+    m_SelectedInstanceIDs: b6670000
+    m_LastClickedInstanceID: 26550
+    m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
@@ -924,7 +924,7 @@ MonoBehaviour:
       m_IsRenaming: 0
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
-      m_ClientGUIView: {fileID: 7}
+      m_ClientGUIView: {fileID: 10}
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
       m_InstanceID: 0
@@ -958,7 +958,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 690
-    width: 1046
+    width: 1186
     height: 309
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -985,19 +985,19 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1047
+    x: 1187
     y: 0
-    width: 873
+    width: 733
     height: 947
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 14}
   m_Panes:
   - {fileID: 14}
   - {fileID: 15}
   - {fileID: 16}
   m_Selected: 0
-  m_LastSelected: 2
+  m_LastSelected: 1
 --- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -1018,9 +1018,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1047
+    x: 1187
     y: 73
-    width: 872
+    width: 732
     height: 926
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1065,9 +1065,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1231
+    x: 1187
     y: 73
-    width: 688
+    width: 732
     height: 926
   m_SerializedDataModeController:
     m_DataMode: 0


### PR DESCRIPTION
# Speed Boost Feature

- Added boostDuration and boostCooldown variables, and SpeedBoostUpdate method to PlayerController.
- The method first checks for the boostCooldown to be 0. If it is, then it checks for the boostDuration to be 0. If it is, then it sets the currentSpeed and currentJumpForce to normal, thus disabling the speed boost.
- This method is only responsible for the disabling of the boost. Activating the boost is shared between Nomad and Pixie activation methods. Read below:

## Nomad Speed Boost

> Nomad needs to be activated for this method to work. It won't work when either Pixie or Titan is active instead of Nomad.

- Added a new key "NomadSpeedBoost" to the Input Map, and set it to Left Shift (can be changed later)

- Added 'nomadSpeedBoostMultiplier' and 'nomadJumpBoostMultiplier' variables, and OnNomadSpeedBoost method to PlayerController

- The script checks for the Nomad speed boost key to be pressed, and when it is pressed, it sets the current speed to the multiplication moveSpeed and nomadSpeedBoostMultiplier. The same goes for the jump force.

## Pixie Speed Boost

> Pixie needs to be activated for this method to work. It won't work when either Nomad or Titan is active instead of Pixie.

- Added 3 new keys to the Input Map to represent each of the combo keys for Pixie. The combo is: Z > X > C in that order. (for now)

- Added 'pixieSpeedBoostMultiplier' and 'pixieJumpBoostMultiplier' variables, and OnPixieSpeedBoost method to PlayerController.

- The script checks for the combo to be completed, and when it is completed, it sets the current speed to the multiplication moveSpeed and pixieSpeedBoostMultiplier. The same goes for the jump force.

     ### Pixie Combo

  - Added pixieCurrentCombo, pixieComboCooldown and pixieComboTimer variables, and OnPixieSpeedBoostCombo methods for the combo activation. And an additional PixieComboUpdate to handle the combo state in general (called inside Update())
  
  - OnPixieSpeedBoostCombo methods (there are 3 in total, representing each 3 combo key) update the pixieCurrentCombo variable. The latest one activates the speed boost feature for Pixie.
  
  - PixieComboUpdate is called inside Update() and is responsible for handling the combo cooldown. If the comboTimer exceeds the pixieComboCooldown, it will set the pixieCurrentCombo variable to 0, and thus resetting the combo.
  
  - The pixieComboCooldown value is currently set to 0.5, meaning that if the next combo key is not pressed within 0.5 seconds, the combo will be cancelled. This value can be increased or decreased from the script, in order to make the combo harder or easier to activate.
